### PR TITLE
Fix issue with System.Net.Http reference

### DIFF
--- a/src/UI/AITOOL.cs
+++ b/src/UI/AITOOL.cs
@@ -357,7 +357,10 @@ namespace AITool
                     }
 
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Log("Error getting next URL: " + ex.ToString());
+                }
 
                 if (ret != null)
                 {

--- a/src/UI/App.config
+++ b/src/UI/App.config
@@ -1,132 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-    </configSections>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
-    </startup>
+  <configSections>
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+  </startup>
   <System.Windows.Forms.ApplicationConfigurationSection>
     <add key="DpiAwareness" value="PerMonitorV2"/>
   </System.Windows.Forms.ApplicationConfigurationSection>
-  
 
   <runtime>
-  
-       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-2.0.4.976" newVersion="2.0.4.976"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-            <dependentAssembly>
-  
-                 <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-  
-                 <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
-  
-            </dependentAssembly>
-  
-       </assemblyBinding>
-  
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SQLitePCLRaw.core" publicKeyToken="1488e028ca7ab535" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.4.976" newVersion="2.0.4.976"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.8.0" newVersion="3.1.8.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/UI/UI.csproj
+++ b/src/UI/UI.csproj
@@ -185,6 +185,10 @@
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Security, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Security.4.3.2\lib\net46\System.Net.Security.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -243,7 +247,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Telegram.Bot, Version=15.7.1.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
In my Windows Server box (no development SDK installed), the System.Net.Http reference wasn't automatically picked up from the GAC, so it needed to be copied to the bin output folder